### PR TITLE
applyValue should always return a value

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -104,7 +104,7 @@ function makeRoot(data) {
 function applyValue(nodeset, mode, attrs, _) {
 
     var modeMatcher = matcher[mode];
-    if (!modeMatcher) { return; }
+    if (!modeMatcher) { return undefined; }
 
     var args;
     var r = '';


### PR DESCRIPTION
Get rid of warning
JS WARN 110: function applyValue does not always return a value
