### PR TITLE
Double percent becomes single

### DIFF
--- a/tests/escaping.14.yate
+++ b/tests/escaping.14.yate
@@ -1,0 +1,12 @@
+/// {
+///     description: 'double percent preserved',
+///     data: {
+///         str: '%%Hello %%'
+///     },
+///     result: '%%Hello %%'
+/// }
+
+match / {
+    .str
+}
+


### PR DESCRIPTION
Написал тест, но, похоже, в тестах тоже баг:
правильный результат `%%Hello %%`
актуальный результат `%Hello %`
но тест проходит...

Тест можно посмотреть из консоли вот так:

``` sh
$ yate tests/escaping.14.yate <(echo "{ str: '%%Hello %%' }")
%Hello %  #  А должно быть %%Hello %% ведь.
```
