### PR TITLE
Strip UTF-8 byte-order-mark from sources and tests

### DIFF
--- a/tests/dotests
+++ b/tests/dotests
@@ -51,7 +51,12 @@ for (var i = 0, l = files.length; i < l; i++) {
     }
     prevSection = section;
 
-    var test = parseTest( fs.readFileSync(filename, 'utf-8') );
+    var testSrc = fs.readFileSync(filename, 'utf-8');
+    // Strip UTF-8 BOM
+    if (testSrc.charAt(0) === '\uFEFF') {
+        testSrc = testSrc.slice(1);
+    }
+    var test = parseTest(testSrc);
     var options = test.options;
     options.yate = filename;
 

--- a/tests/includes/utf8bom.yate
+++ b/tests/includes/utf8bom.yate
@@ -1,0 +1,1 @@
+﻿username = "nop"

--- a/tests/misc.04.yate
+++ b/tests/misc.04.yate
@@ -1,0 +1,10 @@
+﻿/// {
+///     description: 'utf-8 BOM in the beginning of file',
+///     result: '<div>Hello, nop</div>'
+/// }
+include "includes/utf8bom.yate"
+match / {
+	<div>
+	    "Hello, { username }"
+	</div>
+}


### PR DESCRIPTION
Ref: https://github.com/pasaran/parse-tools/pull/2

Fixed the same with test files.
Tests included (misc04)
