### PR TITLE
XML namespace in inline attributes

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -711,10 +711,13 @@ rules.xml_attrs = {
 
 };
 
-//  xml_attr := QNAME '=' inline_string
+//  xml_attr := QNAME ( ':' QNAME )? '=' inline_string
 
 rules.xml_attr = function(p, a) {
     p.Name = this.match('QNAME');
+    if (this.test(':')) {
+        p.Name += this.match(':') + this.match('QNAME');
+    }
     this.match('=');
     p.Value = this.match('inline_string');
 };

--- a/tests/attributes.25.yate
+++ b/tests/attributes.25.yate
@@ -1,0 +1,10 @@
+/// {
+///     description: 'namespaces in attributes',
+///     result: '<div ns:a="a" ns:b="b"></div>'
+/// }
+
+match / {
+    <div ns:a="a">
+        @ns:b = "b"
+    </div>
+}


### PR DESCRIPTION
Хочу писать атрибуты с неймспейсами в тексте.
Проблема этого патча в том, что он позволяет написать

```
<div ns   :   attr = "oops">
```

Хотя может это и не проблема.
