### PR TITLE
monkey-patching `for .*` enumeration for nested arrays

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -679,8 +679,14 @@ yr.selectNametest = function selectNametest(step, context, result) {
     if (!data || typeof data !== 'object') { return result; }
 
     if (step === '*') {
-        for (step in data) {
-            yr.selectNametest(step, context, result);
+        if (data instanceof Array) {
+            for (var i = 0, l = data.length; i < l; i++) {
+                yr.selectNametest(i, context, result);
+            }
+        } else {
+            for (step in data) {
+                yr.selectNametest(step, context, result);
+            }
         }
         return result;
     }


### PR DESCRIPTION
arrays now enumerated using for (;;) instead of for-in
