### PR TITLE
Писать ast для include файлов

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -20,13 +20,11 @@ require('./grammar.js');
 yate.parse = function(filename, options) {
     options = options || {};
 
-    var parser = new pt.Parser(yate.grammar, yate.factory);
-
-    var yastFilename = filename.replace(/\.yate$/, '.yate.ast');
+    var yastFilename = filename + '.ast';
 
     var ast;
 
-    if ( fs_.existsSync(yastFilename) ) {
+    try {
         if ( fs_.statSync(filename).mtime < fs_.statSync(yastFilename).mtime ) {
             var yast = JSON.parse( fs_.readFileSync(yastFilename, 'utf-8') );
 
@@ -35,21 +33,27 @@ yate.parse = function(filename, options) {
                 return ast;
             }
         }
+    } catch(e) {
+        // ignore
     }
 
     try {
+        var parser = new pt.Parser(yate.grammar, yate.factory);
         ast = parser.parse(filename, 'module');
-
-        if ( options['write-ast'] ) {
-            fs_.writeFileSync(yastFilename, yate.AST.serialize(ast), 'utf-8');
-        }
     } catch (e) {
         if (e instanceof pt.Parser.Error) {
             throw Error( e.toString() );
         } else {
             throw e;
         }
+    }
 
+    if ( options['write-ast'] ) {
+        try {
+            fs_.writeFileSync(yastFilename, yate.AST.serialize(ast), 'utf-8');
+        } catch(e) {
+            // ignore
+        }
     }
 
     return ast;
@@ -74,7 +78,7 @@ yate.compile = function(filename, options) {
     /// console.time('walk');
 
     ast.walkdo(function(ast) {
-        ast.w_deinclude();
+        ast.w_deinclude(options);
     });
 
     ast.walkdo(function(ast) {

--- a/lib/asts.js
+++ b/lib/asts.js
@@ -375,14 +375,14 @@ yate.asts.block.w_setTypes = function() {
     }
 };
 
-yate.asts.block.w_deinclude = function() {
+yate.asts.block.w_deinclude = function(options) {
     var a = [];
 
     this.p.Items.iterate(function(item) {
         if (item.id === 'include') {
-            var ast = yate.parse(item.p.Filename, 'module');
+            var ast = yate.parse(item.p.Filename, options);
             ast.dowalk(function(ast) {
-                ast.w_deinclude();
+                ast.w_deinclude(options);
             });
             a = a.concat(ast.p.Block.p.Items.p.Items);
         } else {


### PR DESCRIPTION
Сейчас опция `--write-ast` действует только для корневого файла, потому что в функцию `w_deinclude` не пробрасывается `options`.
- Добавил протаскивание опций в `w_deinclude`;
- убрал `existsSync` и завернул код в `try-catch` — чем меньше синхронных файловых операций, тем лучше.
