### PR TITLE
Разрешить комментарии внутри объектов

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -129,6 +129,8 @@ rules.block = function(p, a, params) {
     //  Блок верхнего уровня (module) заканчивается с концом файла.
     //  Вложенные блоки заканчиваются закрывающей скобкой '}', ']' или ')'.
     while ( !( input.isEOF() || this.testAny('}', ']', ')') ) ) {
+        this.skip('inlineComments');
+
         //  Пропускаем пустые строки.
         if ( input.isEOL() ) {
             this.match('eol');
@@ -945,7 +947,7 @@ rules.inline_primary = {
     },
 
     options: {
-        skipper: 'none'
+        skipper: 'default_'
     }
 
 };

--- a/tests/variables.14.yate
+++ b/tests/variables.14.yate
@@ -1,0 +1,19 @@
+/// {
+///     description: 'it should allow inline comments inside new nodesets',
+///     data: {},
+///     result: 'Hello, World! Answer is 42 number'
+/// }
+
+match / {
+    test({
+        // comment before arg
+        "name": "World"
+        // Comment between args
+        "answer": 42 // and after it
+    })
+}
+
+func test(nodeset params) {
+    "Hello, {params.name}! Answer is {params.answer} number"
+}
+


### PR DESCRIPTION
Фикс https://github.com/pasaran/yate/issues/236
Разрешает использовать комментарий вида `//` внутри объекта